### PR TITLE
Adds __hash__ fun to Method class

### DIFF
--- a/src/someipy/service.py
+++ b/src/someipy/service.py
@@ -65,6 +65,16 @@ class Method:
         self.protocol = protocol
         self.method_handler = method_handler
 
+    def __hash__(self):
+        """ Hashes object.
+
+        Returns
+        -------
+        int
+            Hash of object
+        """
+        return hash((self.id,self.protocol))
+
     def __eq__(self, __value: object) -> bool:
         """Check equality with another Method based on id and protocol.
 


### PR DESCRIPTION
Missing __hash__ function leads to thrown TypeException, Method not hashable, when trying to crete an RPC client.

Presumably __eq__ was added recently. Manually adding __eq__ to a dataclass, leads to __hash__ no longer being generated by default

Test: manually, library doesnt throw expections on my setup anymore